### PR TITLE
tplink config integration deprecated

### DIFF
--- a/packages/tplink_kasa.yaml
+++ b/packages/tplink_kasa.yaml
@@ -1,6 +1,6 @@
 ## this package is used for adding TPLink Kasa lights that wont get found by integration
 
-tplink:
-  discovery: false
-  switch: 
-    - host: 192.168.1.211
+# tplink:
+#   discovery: false
+#   switch:
+#     - host: 192.168.1.211


### PR DESCRIPTION
The 'tplink' option near /config/configuration.yaml:3 is deprecated, please remove it from your configuration